### PR TITLE
GCode updates

### DIFF
--- a/src/drivers/neopixel.c
+++ b/src/drivers/neopixel.c
@@ -39,3 +39,10 @@ void Neopixel_set(uint8_t* pixels, size_t n, uint8_t r, uint8_t g, uint8_t b) {
     pixels[offset + 1] = r;
     pixels[offset + 2] = b;
 }
+
+void Neopixel_get(uint8_t* pixels, size_t n, uint8_t* r, uint8_t* g, uint8_t* b) {
+    size_t offset = n * 3;
+    *g = pixels[offset];
+    *r = pixels[offset + 1];
+    *b = pixels[offset + 2];
+}

--- a/src/drivers/neopixel.h
+++ b/src/drivers/neopixel.h
@@ -13,6 +13,7 @@ https://opensource.org/licenses/MIT. */
 void Neopixel_init(uint32_t pin);
 void Neopixel_write(uint8_t* pixels, size_t count);
 void Neopixel_set(uint8_t* pixels, size_t n, uint8_t r, uint8_t g, uint8_t b);
+void Neopixel_get(uint8_t* pixels, size_t n, uint8_t* r, uint8_t* g, uint8_t* b);
 
 inline void Neopixel_set_all(uint8_t* pixels, size_t count, uint8_t r, uint8_t g, uint8_t b) {
     for (size_t x = 0; x < count; x++) { Neopixel_set(pixels, x, r, g, b); }

--- a/src/machine.c
+++ b/src/machine.c
@@ -120,8 +120,18 @@ void Machine_set_linear_acceleration(struct Machine* m, float accel_mm_s2) {
 #ifdef HAS_Z_AXIS
     m->z.acceleration_mm_s2 = accel_mm_s2;
 #endif
+}
 
-    report_result_ln("T:%0.2f mm/s^2", (double)accel_mm_s2);
+void Machine_report_linear_acceleration(struct Machine* m) {
+    double accel = 0;
+#ifdef HAS_XY_AXES
+    // Using only X axis as they are configured above to be equal
+    accel = m->x.acceleration_mm_s2;
+#endif
+#ifdef HAS_Z_AXIS
+    accel = m->z.acceleration_mm_s2;
+#endif
+    report_result_ln("T:%0.2f mm/s^2", accel);
 }
 
 void Machine_set_motor_current(struct Machine* m, const struct lilg_Command cmd) {

--- a/src/machine.h
+++ b/src/machine.h
@@ -38,6 +38,7 @@ void Machine_enable_steppers(struct Machine* m);
 void Machine_disable_steppers(struct Machine* m);
 void Machine_set_linear_velocity(struct Machine* m, float vel_mm_s);
 void Machine_set_linear_acceleration(struct Machine* m, float accel_mm_s2);
+void Machine_report_linear_acceleration(struct Machine* m);
 void Machine_set_motor_current(struct Machine* m, const struct lilg_Command cmd);
 void Machine_set_homing_sensitivity(struct Machine* m, const struct lilg_Command cmd);
 void Machine_home(struct Machine* m, bool x, bool y, bool z);


### PR DESCRIPTION
Added GCodes:
* G21 - no-op, OpenPnP sends this by default in CONNECT_COMMAND.
* M82 - no-op, OpenPnP sends this by default in CONNECT_COMMAND.
* M112 - emergency stop, disables steppers, disables pumps/valves (Starfish only), sets LEDs to RED.
* M503 - reports settings
* M999 - forces reboot via watchdog

Updated GCodes:
* M150 - added support for 'K', 'U', 'I' and 'P'
* M204 - added support to run without args to display current settings.